### PR TITLE
Improve Python3 compatibility

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -56,7 +56,7 @@ class Airtable:
                 message = None
                 r.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                message = e.message
+                message = e
             return {
                 'error': dict(code=r.status_code, message=message)
             }


### PR DESCRIPTION
e.message breaks in Python3. But simply assigning the error itself to the message works in Python2 and Python3. 

Manually tested with a 404 error, plus ran unit tests in Python2 and all pass.
