### PR TITLE
Added a User-Agent Header to requests headers

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -41,7 +41,7 @@ class Airtable(object):
     def __init__(self, base_id, api_key):
         self.airtable_url = API_URL % API_VERSION
         self.base_url = posixpath.join(self.airtable_url, base_id)
-        self.headers = {'Authorization': 'Bearer %s' % api_key}
+        self.headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:39.0)', 'Authorization': 'Bearer %s' % api_key}
 
     def __request(self, method, url, params=None, payload=None):
         if method in ['POST', 'PUT', 'PATCH']:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='airtable',
-    version='0.3.1',
+    version='0.3.2',
     packages=['airtable'],
     install_requires=['requests>=2.5.3'],
     description='Python client library for AirTable',


### PR DESCRIPTION
I used this library successfully on my personal computer (a Macbook), but when attempting to run it on my work computer (a Windows laptop), the library was failing. After further investigation it seemed to be due to there not being a User-Agent header in the requests object, so I added one in.