### PR TITLE
Allow "from airtable import Airtable"

### DIFF
--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from .airtable import Airtable

--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -1,1 +1,1 @@
-from airtable import Airtable
+from .airtable import Airtable

--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -1,1 +1,1 @@
-#from airtable import Airtable
+from airtable import Airtable


### PR DESCRIPTION
A number of users of this library have been confused that they have to do:
    from airtable.airtable import Airtable

The less surprising (and more python-idiomatic) way to import would be:
    from airtable import Airtable

This pull request enables that.