### PR TITLE
Adding support to bulk record creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ at.create_bulk(table_name, data)
 where
 ```
 table_name (required) is a string representing the table name
-data (required) is a list of dictionaries containing the fields and the resepective values
+data (required) is a list of dictionaries containing the fields and the respective values
 ```
 
 ### Update

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ data (required) is a dictionary containing the fields and the resepective values
 
 ### Create_bulk
 
-Creates several new entries in a table, and returns the newly created entries with its new ID, if
+Creates several new entries in a table, and returns the newly created entries with their new IDs, if
 there is an error trying to create a subset of records it returns the records not created in "records_failed".
 
 ```python

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ table_name (required) is a string representing the table name
 data (required) is a dictionary containing the fields and the resepective values
 ```
 
+### Create_bulk
+
+Creates several new entries in a table, and returns the newly created entries with its new ID, if
+there is an error trying to create a subset of records it returns the records not created in "records_failed".
+
+```python
+at.create_bulk(table_name, data)
+```
+where
+```
+table_name (required) is a string representing the table name
+data (required) is a list of dictionaries containing the fields and the resepective values
+```
+
 ### Update
 Updates *some* fields in a specific entry in the table. Fields which are not explicitely included will not get updated
 ```python

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 API_URL = 'https://api.airtable.com/v%s/'
 API_VERSION = '0'
-BULK_LIMIT = 10
+BULK_LIMIT = 10 # Airtable limit
 
 
 class IsNotInteger(Exception):
@@ -146,11 +146,11 @@ class Airtable(object):
 
     def _create_batch(self, table_name, batch):
         batch_result = self.__request('POST', table_name,
-            payload=json.dumps({"records": batch}))
+            payload=json.dumps({'records': batch}))
         if not "error" in batch_result:
             return batch_result
-        else:
-            raise ErrorStoringBatch("Error creating records in the batch")
+
+        raise ErrorStoringBatch('Error creating records in the batch')
 
     def bulk_create(self, table_name, data):
         if check_string(table_name):
@@ -158,10 +158,10 @@ class Airtable(object):
             records_stored = []
             records_failed = []
             for idx, record in enumerate(data):
-                if (payload and idx % BULK_LIMIT == 0):
+                if payload and idx % BULK_LIMIT == 0:
                     try:
                         batch_result = self._create_batch(table_name, payload)
-                        records_stored.extend(batch_result["records"])
+                        records_stored.extend(batch_result['records'])
                     except ErrorStoringBatch as e:
                         records_failed.append(payload)
                     payload = []
@@ -170,14 +170,14 @@ class Airtable(object):
             if payload:
                 try:
                     batch_result = self._create_batch(table_name, payload)
-                    records_stored.extend(batch_result["records"])
+                    records_stored.extend(batch_result['records'])
                 except ErrorStoringBatch as e:
                     records_failed.append(payload)
 
             if records_failed:
-                return {"records": records_stored, "records_failed": records_failed}
-            else:
-                return {"records": records_stored}
+                return {'records': records_stored, 'records_failed': records_failed}
+
+            return {'records': records_stored}
 
     def update(self, table_name, record_id, data):
         if check_string(table_name) and check_string(record_id):

--- a/airtable/airtable.pyi
+++ b/airtable/airtable.pyi
@@ -64,7 +64,7 @@ class Airtable(object):
     def create(self, table_name: str, data: typing.Dict[str, typing.Any]) -> _Record:
         ...
 
-    def create_bulk(self, table_name: str, data: typing.List[typing.Dict[str, typing.Any]]) -> _Record:
+    def create_bulk(self, table_name: str, data: typing.Iterator[typing.Dict[str, typing.Any]]) -> _Record:
         ...
 
     def update(self, table_name: str, record_id: str, data: typing.Dict[str, typing.Any]) -> _Record:

--- a/airtable/airtable.pyi
+++ b/airtable/airtable.pyi
@@ -63,7 +63,10 @@ class Airtable(object):
 
     def create(self, table_name: str, data: typing.Dict[str, typing.Any]) -> _Record:
         ...
- 
+
+    def create_bulk(self, table_name: str, data: typing.List[typing.Dict[str, typing.Any]]) -> _Record:
+        ...
+
     def update(self, table_name: str, record_id: str, data: typing.Dict[str, typing.Any]) -> _Record:
         ...
 

--- a/airtable/airtable.pyi
+++ b/airtable/airtable.pyi
@@ -64,7 +64,7 @@ class Airtable(object):
     def create(self, table_name: str, data: typing.Dict[str, typing.Any]) -> _Record:
         ...
 
-    def create_bulk(self, table_name: str, data: typing.Iterator[typing.Dict[str, typing.Any]]) -> _Record:
+    def create_bulk(self, table_name: str, data: typing.Iterable[typing.Mapping[str, typing.Any]]) -> _Record:
         ...
 
     def update(self, table_name: str, record_id: str, data: typing.Dict[str, typing.Any]) -> _Record:

--- a/airtable/airtable_test.py
+++ b/airtable/airtable_test.py
@@ -5,7 +5,6 @@ import os
 import requests
 import unittest
 
-
 FAKE_TABLE_NAME = 'TableName'
 FAKE_BASE_ID = 'app12345'
 FAKE_API_KEY = 'fake_api_key'

--- a/airtable/airtable_test.py
+++ b/airtable/airtable_test.py
@@ -152,11 +152,11 @@ class TestAirtable(unittest.TestCase):
         with self.assertRaises(airtable.IsNotString):
             self.airtable.delete(FAKE_TABLE_NAME, 123)
 
-TABLE_NAME = os.environ.get("AIRTABLE_TEST_TABLE_NAME")
-BASE_ID = os.environ.get("AIRTABLE_TEST_BASE_ID")
-API_KEY = os.environ.get("AIRTABLE_TEST_API_KEY")
+TABLE_NAME = os.environ.get('AIRTABLE_TEST_TABLE_NAME')
+BASE_ID = os.environ.get('AIRTABLE_TEST_BASE_ID')
+API_KEY = os.environ.get('AIRTABLE_TEST_API_KEY')
 
-@unittest.skipUnless(TABLE_NAME and BASE_ID and API_KEY, "Need to set up AIRTABLE TEST environment variables")
+@unittest.skipUnless(TABLE_NAME and BASE_ID and API_KEY, 'Need to set up AIRTABLE TEST environment variables')
 class TestAirtableIntegration(unittest.TestCase):
     def setUp(self):
         self.table_name = TABLE_NAME

--- a/airtable/airtable_test.py
+++ b/airtable/airtable_test.py
@@ -194,7 +194,7 @@ class TestAirtableIntegration(unittest.TestCase):
             })
 
         res = self.airtable.bulk_create(self.table_name, data)
-        self.assertFalse('error' in res)
+        self.assertNotIn('error', res)
         self.assertTrue('records' in res and len(res['records']) == records_number)
 
 if __name__ == '__main__':

--- a/airtable/airtable_test.py
+++ b/airtable/airtable_test.py
@@ -169,7 +169,7 @@ class TestAirtableIntegration(unittest.TestCase):
             'Name': 'John',
             'Number': '(987) 654-3210'
         })
-        self.assertFalse("error" in res)
+        self.assertNotIn('error', res)
 
     def test_create_bulk(self):
         data = []
@@ -181,8 +181,8 @@ class TestAirtableIntegration(unittest.TestCase):
             })
 
         res = self.airtable.bulk_create(self.table_name, data)
-        self.assertFalse("error" in res)
-        self.assertTrue("records" in res and len(res["records"]) == records_number)
+        self.assertNotIn('error', res)
+        self.assertTrue('records' in res and len(res['records']) == records_number)
 
     def test_create_bulk_small_batch(self):
         data = []
@@ -194,8 +194,8 @@ class TestAirtableIntegration(unittest.TestCase):
             })
 
         res = self.airtable.bulk_create(self.table_name, data)
-        self.assertFalse("error" in res)
-        self.assertTrue("records" in res and len(res["records"]) == records_number)
+        self.assertFalse('error' in res)
+        self.assertTrue('records' in res and len(res['records']) == records_number)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
airtable since 2019-09 supports creation up to 10 records in one API request.

This pull request adds a method called bulk_create that receives

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/josephbestjames/airtable.py/26)
<!-- Reviewable:end -->
