### PR TITLE
feat: add retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 /AUTHORS
 /ChangeLog
 /.eggs
+/.vscode

--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Generic, Mapping, TypeVar
 import warnings
 
 import requests
+from requests.packages.urllib3.util.retry import Retry
 import six
 
 API_URL = 'https://api.airtable.com/v%s/'
@@ -91,10 +92,15 @@ class Airtable(object):
         self.headers = {'Authorization': 'Bearer %s' % api_key}
         self._dict_class = dict_class
 
+    
+
     def __request(self, method, url, params=None, payload=None):
         if method in ['POST', 'PUT', 'PATCH']:
             self.headers.update({'Content-type': 'application/json'})
-        response = requests.request(
+        retries = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+        session = requests.Session()
+        session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+        response = session.request(
             method,
             posixpath.join(self.base_url, url),
             params=params,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pylint
 flake8
 requests-mock
+httpretty


### PR DESCRIPTION
Airtable rate limits to 5 requests per second across all bases. They return http code 429 when you hit this limit.
This PR introduces retries via the requests retry functionality with back off so this error can be avoided.

I think this is a better approach than local rate limiting as there maybe multiple clients accessing the API, and is more aligned with the official node library